### PR TITLE
Shiny app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,7 @@ License: Artistic-2.0 | BSL-1.0 | file LICENSE
 Encoding: UTF-8
 Collate: db.R collections.R datasets.R files.R facets.R keys.R
     cellxgene.R utilities.R cpp11.R jmespath.R app.R
-Imports: dplyr, httr, curl, jsonlite, utils, tools, parallel, shiny,
-    shinyWidgets, DT
+Imports: dplyr, httr, curl, jsonlite, utils, tools, parallel, shiny, DT
 LinkingTo: cpp11
 Suggests:
     zellkonverter,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,8 +23,9 @@ Description: The cellxgene data portal
 License: Artistic-2.0 | BSL-1.0 | file LICENSE
 Encoding: UTF-8
 Collate: db.R collections.R datasets.R files.R facets.R keys.R
-    cellxgene.R utilities.R cpp11.R jmespath.R
-Imports: dplyr, httr, curl, jsonlite, utils, tools, parallel
+    cellxgene.R utilities.R cpp11.R jmespath.R app.R
+Imports: dplyr, httr, curl, jsonlite, utils, tools, parallel, shiny,
+    shinyWidgets, DT
 LinkingTo: cpp11
 Suggests:
     zellkonverter,

--- a/R/app.R
+++ b/R/app.R
@@ -1,0 +1,159 @@
+library(shiny)
+library(shinyWidgets)
+library(DT)
+library(dplyr)
+
+ui <- navbarPage(
+    title = 'cellxgene data', id = 'tabs',
+
+    tabPanel("Collections", DT::dataTableOutput("collections")),
+    tabPanel("Datasets", DT::dataTableOutput("datasets"))
+)
+
+.pullLabels <- function(x) {
+    labels <- vapply(x, `[[`, character(1), "label")
+    paste(labels, collapse = ", ")
+}
+
+.shiny_collections <- function(db) {
+    collections <- collections(db) |>
+        select(c(collection_id, name))
+
+    datasets <- datasets(db) |>
+        select(c(collection_id, tissue, assay, disease, organism, cell_count))
+
+    labeledDat <- datasets |>
+        mutate_at(c("tissue", "assay", "disease", "organism"),
+            function(x) vapply(x, .pullLabels, character(1))
+        ) |> group_by(collection_id) |>
+        summarise_at(c("tissue", "assay", "disease", "organism"),
+            function(x) paste(unique(x), collapse = ", ")
+        )
+
+    countDat <- datasets |>
+        group_by(collection_id) |>
+        summarise(cell_count = sum(cell_count))
+
+    allDat <- left_join(collections, labeledDat, by = "collection_id") |>
+        left_join(countDat, by = "collection_id")
+    allDat
+}
+
+.shiny_datasets <- function(db, id) {
+    tbl <- datasets(db) |>
+        select(c(dataset_id, collection_id, name, tissue, assay, disease,
+            organism, cell_count)) |>
+        mutate_at(c("tissue", "assay", "disease", "organism"),
+            function(x) vapply(x, .pullLabels, character(1))
+        ) |>
+        mutate(Download = as.character(icon("cloud-download", lib = "glyphicon"))) |>
+        mutate(Visualize = as.character(icon("eye-open", lib = "glyphicon"))) |>
+        select(c(1, 2, 9, 10, 3, 4, 5, 6, 7, 8))
+
+    if (!is.null(id))
+        tbl <- tbl |> filter(collection_id == id)
+    tbl
+}
+
+.shiny_files <- function(db, id) {
+    tbl <- files(db)
+
+    if (!is.null(id))
+        tbl <- tbl |> filter(dataset_id == id)
+    tbl
+}
+
+server <- function(input, output, session) {
+    db <- db()
+    collections <- .shiny_collections(db)
+    dataset <- .shiny_datasets(db, id = NULL)
+    files <- .shiny_files(db, id = NULL)
+    output$collections <- DT::renderDataTable({
+        DT::datatable(collections,
+            selection = 'single',
+            filter = 'top',
+            colnames = c('rownames', 'id', 'Collections', 'Tissue', 'Assay', 
+                'Disease', 'Organism', 'Cell Count'),
+            options = list(
+                scrollY = 400,
+                columnDefs = list(
+                    list(visible = FALSE, targets = c(0,1)),
+                    list(width = '110px', targets = c(3,4,5,6,7))
+                )
+            )
+        )
+    })
+
+    output$datasets <- DT::renderDataTable({
+        DT::datatable(dataset,
+            selection = 'single',
+            filter = 'top',
+            escape = FALSE,
+            colnames = c('rownames', 'dat_id', 'col_id', '', '', 'Datasets', 
+                'Tissue', 'Assay', 'Disease', 'Organism', 'Cell Count'),
+            options = list(
+                dom = 'ft',
+                scrollX = TRUE,
+                scrollY = 400,
+                autoWidth = TRUE,
+                columnDefs = list(
+                    list(orderable = FALSE, targets = c(3,4)),
+                    list(searchable = FALSE, targets = c(3,4)),
+                    list(visible = FALSE, targets = c(0,1,2)),
+                    list(width = '10px', targets = c(3,4)),
+                    list(width = '110px', targets = c(6,7,8,9,10)),
+                    list(className = 'dt-center', targets = c(3,4))
+                )
+            )
+        )
+    })
+
+    observeEvent(input$collections_cell_clicked, {
+        info <- input$collections_cell_clicked
+        if (is.null(info$value)) return()
+        id <- collections[input$collections_row_last_clicked, "collection_id"][[1]]
+        dataset <<- .shiny_datasets(db, id)
+        output$datasets <- DT::renderDataTable({
+            DT::datatable(dataset,
+                selection = 'single',
+                filter = 'top',
+                escape = FALSE,
+                colnames = c('rownames', 'dat_id', 'col_id', '', '', 'Datasets', 
+                    'Tissue', 'Assay', 'Disease', 'Organism', 'Cell Count'),
+                options = list(
+                    dom = 'ft',
+                    scrollY = 400,
+                    autoWidth = TRUE,
+                    columnDefs = list(
+                        list(visible = FALSE, targets = c(0,1,2)),
+                        list(width = '10px', targets = c(3,4)),
+                        list(width = '110px', targets = c(6,7,8,9,10)),
+                        list(className = 'dt-center', targets = c(3,4))
+                    )
+                )
+            )
+        })
+        updateTabsetPanel(session, 'tabs', selected = 'Datasets')
+    })
+
+    observeEvent(input$datasets_cell_clicked, {
+        info <- input$datasets_cell_clicked
+        if (is.null(info$value)) return()
+        id <- dataset[input$datasets_row_last_clicked, "dataset_id"][[1]]
+        files <<- .shiny_files(db, id)
+
+        if (info$col == 3) {
+            local_files <- files |>
+            filter(filetype == "H5AD") |>
+            slice(1) |>
+            files_download(dry.run = FALSE)
+            
+        } else if (info$col == 4) {
+            files |>
+                filter(filetype == "CXG") |>
+                slice(1) |>
+                datasets_visualize()
+        } else 
+            return()
+    })
+}

--- a/R/app.R
+++ b/R/app.R
@@ -1,7 +1,9 @@
 library(shiny)
-library(shinyWidgets)
 library(DT)
 library(dplyr)
+
+collection_id <- name <- tissue <- assay <- disease <- organism <- cell_count <- 
+    dataset_id <- filetype <- NULL
 
 ui <- navbarPage(
     title = 'cellxgene data', id = 'tabs',
@@ -23,35 +25,35 @@ ui <- navbarPage(
         select(c(collection_id, tissue, assay, disease, organism, cell_count))
 
     labeledDat <- datasets |>
-        mutate_at(c("tissue", "assay", "disease", "organism"),
+        dplyr::mutate_at(c("tissue", "assay", "disease", "organism"),
             function(x) vapply(x, .pullLabels, character(1))
-        ) |> group_by(collection_id) |>
-        summarise_at(c("tissue", "assay", "disease", "organism"),
+        ) |> dplyr::group_by(collection_id) |>
+        dplyr::summarise_at(c("tissue", "assay", "disease", "organism"),
             function(x) paste(unique(x), collapse = ", ")
         )
 
     countDat <- datasets |>
-        group_by(collection_id) |>
-        summarise(cell_count = sum(cell_count))
+        dplyr::group_by(collection_id) |>
+        dplyr::summarise(cell_count = sum(cell_count))
 
-    allDat <- left_join(collections, labeledDat, by = "collection_id") |>
-        left_join(countDat, by = "collection_id")
+    allDat <- dplyr::left_join(collections, labeledDat, by = "collection_id") |>
+        dplyr::left_join(countDat, by = "collection_id")
     allDat
 }
 
 .shiny_datasets <- function(db, id) {
     tbl <- datasets(db) |>
-        select(c(dataset_id, collection_id, name, tissue, assay, disease,
+        dplyr::select(c(dataset_id, collection_id, name, tissue, assay, disease,
             organism, cell_count)) |>
-        mutate_at(c("tissue", "assay", "disease", "organism"),
+        dplyr::mutate_at(c("tissue", "assay", "disease", "organism"),
             function(x) vapply(x, .pullLabels, character(1))
         ) |>
-        mutate(Download = as.character(icon("cloud-download", lib = "glyphicon"))) |>
-        mutate(Visualize = as.character(icon("eye-open", lib = "glyphicon"))) |>
-        select(c(1, 2, 9, 10, 3, 4, 5, 6, 7, 8))
+        dplyr::mutate(Download = as.character(shiny::icon("cloud-download", lib = "glyphicon"))) |>
+        dplyr::mutate(Visualize = as.character(shiny::icon("eye-open", lib = "glyphicon"))) |>
+        dplyr::select(c(1, 2, 9, 10, 3, 4, 5, 6, 7, 8))
 
     if (!is.null(id))
-        tbl <- tbl |> filter(collection_id == id)
+        tbl <- tbl |> dplyr::filter(collection_id == id)
     tbl
 }
 
@@ -59,7 +61,7 @@ ui <- navbarPage(
     tbl <- files(db)
 
     if (!is.null(id))
-        tbl <- tbl |> filter(dataset_id == id)
+        tbl <- tbl |> dplyr::filter(dataset_id == id)
     tbl
 }
 
@@ -108,7 +110,7 @@ server <- function(input, output, session) {
         )
     })
 
-    observeEvent(input$collections_cell_clicked, {
+    shiny::observeEvent(input$collections_cell_clicked, {
         info <- input$collections_cell_clicked
         if (is.null(info$value)) return()
         id <- collections[input$collections_row_last_clicked, "collection_id"][[1]]
@@ -133,10 +135,10 @@ server <- function(input, output, session) {
                 )
             )
         })
-        updateTabsetPanel(session, 'tabs', selected = 'Datasets')
+        shiny::updateTabsetPanel(session, 'tabs', selected = 'Datasets')
     })
 
-    observeEvent(input$datasets_cell_clicked, {
+    shiny::observeEvent(input$datasets_cell_clicked, {
         info <- input$datasets_cell_clicked
         if (is.null(info$value)) return()
         id <- dataset[input$datasets_row_last_clicked, "dataset_id"][[1]]
@@ -144,14 +146,14 @@ server <- function(input, output, session) {
 
         if (info$col == 3) {
             local_files <- files |>
-            filter(filetype == "H5AD") |>
-            slice(1) |>
+            dplyr::filter(filetype == "H5AD") |>
+            dplyr::slice(1) |>
             files_download(dry.run = FALSE)
             
         } else if (info$col == 4) {
             files |>
-                filter(filetype == "CXG") |>
-                slice(1) |>
+                dplyr::filter(filetype == "CXG") |>
+                dplyr::slice(1) |>
                 datasets_visualize()
         } else 
             return()


### PR DESCRIPTION
`shiny_cxg()` runs the shiny app. There is now a sidebar that prints the number of datasets that will be downloaded and converted (depending on how many dataset rows are selected) as well a 'Convert and quit' button. Default shows the downloaded files as a tibble, but user can run `shiny_cxg('list')` to get results as a `SingleCellExperiment` object. Happy to make any additional changes.