### PR TITLE
Change to reorder tabs for shiny app

### DIFF
--- a/R/cxg.R
+++ b/R/cxg.R
@@ -209,16 +209,16 @@
         'cellxgenedp',
 
         tabPanel(
-            "Collections",
-            DT::dataTableOutput("collections")
-        ),
-        tabPanel(
             "Datasets",
             textOutput("datasets_selected", inline = TRUE),
             actionButton("quit_and_download", "Quit and download"),
             actionButton("quit", "Quit"),
             hr(),
             DT::dataTableOutput("datasets")
+        ),
+        tabPanel(
+            "Collections",
+            DT::dataTableOutput("collections")
         ),
 
         id = "navbar"


### PR DESCRIPTION
This code reorders the tabs similar to cellxgene app layout.